### PR TITLE
Bugfix: System.Threading.ThreadAbortException on every redirect..

### DIFF
--- a/src/Core/CustomRedirects/CustomRedirectCollection.cs
+++ b/src/Core/CustomRedirects/CustomRedirectCollection.cs
@@ -110,6 +110,11 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
                             return cr;
                         }
 
+                        // Lets say we have a redirect: http://foo.no/bar with WildCardSkipAppend = false
+                        // then http://foo.no/barr wil give "ERR_INVALID_REDIRECT"
+                        if (!url.Substring(key.Length).StartsWith("/"))
+                            return null;
+
                         // We need to append the 404 to the end of the
                         // new one. Make a copy of the redir object as we
                         // are changing it.

--- a/src/Core/Web/HttpContextBaseExtensions.cs
+++ b/src/Core/Web/HttpContextBaseExtensions.cs
@@ -22,7 +22,8 @@ namespace BVNetwork.NotFound.Core.Web
         {
             context.Response.Clear();
             context.Response.TrySkipIisCustomErrors = true;
-            context.Response.RedirectPermanent(url);
+            context.Response.RedirectPermanent(url, false);
+            context.ApplicationInstance.CompleteRequest();
             return context;
         }
 


### PR DESCRIPTION
This happens on every redirect: 
ERROR BVNetwork.NotFound.Core.Initialization.Custom404HandlerInitialization: Error on 404 handling.
System.Threading.ThreadAbortException: Thread was being aborted.
   at System.Threading.Thread.AbortInternal()
   at System.Threading.Thread.Abort(Object stateInfo)
   at System.Web.HttpResponse.AbortCurrentThread()
   at System.Web.HttpResponse.Redirect(String url, Boolean endResponse, Boolean permanent)
   at System.Web.HttpResponseWrapper.RedirectPermanent(String url)
   at BVNetwork.NotFound.Core.Web.HttpContextBaseExtensions.RedirectPermanent(HttpContextBase context, String url)
   at BVNetwork.NotFound.Core.RequestHandler.Handle(HttpContextBase context)
   at BVNetwork.NotFound.Core.Initialization.Custom404HandlerInitialization.OnEndRequest(Object sender, EventArgs eventArgs)