### PR TITLE
duplicate oldUrl fix

### DIFF
--- a/src/Geta.404Handler/Controllers/NotFoundRedirectController.cs
+++ b/src/Geta.404Handler/Controllers/NotFoundRedirectController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Geta Digital. All rights reserved.
+﻿// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System;
@@ -120,11 +120,10 @@ namespace BVNetwork.NotFound.Controllers
         }
 
         [ValidateInput(false)]
-        public ActionResult Save(string oldUrl, string newUrl, string skipWildCardAppend, string redirectType, int? pageNumber, int? pageSize)
+        public ActionResult Save(string oldUrl, string newUrl, string skipWildCardAppend, RedirectType redirectType, int? pageNumber, int? pageSize)
         {
             CheckAccess();
-            RedirectType type = (RedirectType)Enum.Parse(typeof(RedirectType), redirectType);
-            SaveRedirect(oldUrl, newUrl, skipWildCardAppend, type);
+            SaveRedirect(oldUrl, newUrl, skipWildCardAppend, redirectType);
             List<CustomRedirect> redirectList = GetData(null);
             string actionInfo = string.Format(LocalizationService.Current.GetString("/gadget/redirects/saveredirect"), oldUrl, newUrl);
             return View("Index", GetRedirectIndexViewData(pageNumber, redirectList, actionInfo, null, pageSize, false, true));

--- a/src/Geta.404Handler/Controllers/NotFoundRedirectController.cs
+++ b/src/Geta.404Handler/Controllers/NotFoundRedirectController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Geta Digital. All rights reserved.
+// Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
 using System;
@@ -120,10 +120,11 @@ namespace BVNetwork.NotFound.Controllers
         }
 
         [ValidateInput(false)]
-        public ActionResult Save(string oldUrl, string newUrl, string skipWildCardAppend, RedirectType redirectType, int? pageNumber, int? pageSize)
+        public ActionResult Save(string oldUrl, string newUrl, string skipWildCardAppend, string redirectType, int? pageNumber, int? pageSize)
         {
             CheckAccess();
-            SaveRedirect(oldUrl, newUrl, skipWildCardAppend, redirectType);
+            RedirectType type = (RedirectType)Enum.Parse(typeof(RedirectType), redirectType);
+            SaveRedirect(oldUrl, newUrl, skipWildCardAppend, type);
             List<CustomRedirect> redirectList = GetData(null);
             string actionInfo = string.Format(LocalizationService.Current.GetString("/gadget/redirects/saveredirect"), oldUrl, newUrl);
             return View("Index", GetRedirectIndexViewData(pageNumber, redirectList, actionInfo, null, pageSize, false, true));

--- a/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectHandler.cs
+++ b/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectHandler.cs
@@ -48,7 +48,15 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
 
             foreach (var redirect in RedirectsService.GetAll())
             {
-                _customRedirects.Add(redirect);
+                try
+                {
+                    _customRedirects.Add(redirect);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(string.Format("An error occurred while loading redirect OldUrl = {0}", redirect.OldUrl), ex);
+                    CustomRedirectHandlerException = ex.ToString();
+                }
             }
         }
 


### PR DESCRIPTION
When there are duplicated urlOld's on the DB table, _customRedirects.Add(); crashes and does not continue with completing list. 
I added try clause on each iteration to continue building list even if duplicates are present.
