### PR TITLE
Fix when duplicated custom redirect is added to the collection

### DIFF
--- a/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectCollection.cs
+++ b/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectCollection.cs
@@ -69,6 +69,12 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
 
         public void Add(CustomRedirect customRedirect)
         {
+            if (_quickLookupTable.ContainsKey(customRedirect.OldUrl))
+            {
+                _quickLookupTable[customRedirect.OldUrl] = customRedirect;
+                return;
+            }
+
             // Add to quick look up table too
             _quickLookupTable.Add(customRedirect.OldUrl, customRedirect);
 

--- a/tests/Geta.404Handler.Tests/CustomRedirectCollectionTests.cs
+++ b/tests/Geta.404Handler.Tests/CustomRedirectCollectionTests.cs
@@ -130,6 +130,20 @@ namespace BVNetwork.NotFound.Tests
             Assert.Null(actual);
         }
 
+        [Fact]
+        public void Add_updates_already_added_redirect()
+        {
+            var redirect = new CustomRedirect(DefaultOldUri.PathAndQuery, DefaultNewUri.ToString());
+            _sut.Add(redirect);
+            var updatedUrl = "http://example.com/expected";
+            var updatedRedirect = new CustomRedirect(DefaultOldUri.PathAndQuery, updatedUrl);
+
+            _sut.Add(updatedRedirect);
+
+            var actual = _sut.Find(DefaultOldUri);
+            Assert.Equal(updatedUrl, actual.NewUrl);
+        }
+
         // Regression tests
 
         /// <summary>


### PR DESCRIPTION
This might happen when there was some issue with DB data. It should not break the site.