### PR TITLE
Safe-guard-empry-oldUrl

### DIFF
--- a/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectCollection.cs
+++ b/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectCollection.cs
@@ -112,7 +112,7 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
             {
                 var oldUrl = redirectPair.Key;
                 // See if this "old" url (the one that cannot be found) starts with one
-                if (!string.IsNullOrEmpty(oldUrl) && url.StartsWith(oldUrl, StringComparison.InvariantCultureIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(oldUrl) && url.StartsWith(oldUrl, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var cr = redirectPair.Value;
                     if (cr.State == (int)RedirectState.Ignored)

--- a/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectCollection.cs
+++ b/src/Geta.404Handler/Core/CustomRedirects/CustomRedirectCollection.cs
@@ -112,7 +112,7 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
             {
                 var oldUrl = redirectPair.Key;
                 // See if this "old" url (the one that cannot be found) starts with one
-                if (oldUrl != null && url.StartsWith(oldUrl, StringComparison.InvariantCultureIgnoreCase))
+                if (!string.IsNullOrEmpty(oldUrl) && url.StartsWith(oldUrl, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var cr = redirectPair.Value;
                     if (cr.State == (int)RedirectState.Ignored)
@@ -139,7 +139,7 @@ namespace BVNetwork.NotFound.Core.CustomRedirects
         {
             string AppendSlash(string s)
             {
-                if(s == null)
+                if (s == null)
                     return s;
 
                 return s.EndsWith("/") ? s : $"{s}/";


### PR DESCRIPTION
Prevent a potential infinite loop in the edge case where oldUrl is empty